### PR TITLE
Update Vagrantfile to fix SSH issues

### DIFF
--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -3,9 +3,7 @@
 
 Vagrant.configure(2) do |config|
 
-  config.ssh.username = 'vagrant'
-  config.ssh.password = 'vagrant'
-  config.ssh.insert_key = true
+  config.ssh.insert_key = false
 
   config.hostmanager.enabled = true
   config.hostmanager.ignore_private_ip = false


### PR DESCRIPTION
Error is:
Key inserted! Disconnecting and reconnecting using new SSH key...
Warning: Authentication failure. Retrying...
... and vagrant up fails at that point after many retries

Fix is to add `config.ssh.insert_key = false`
